### PR TITLE
Don't clear input field on building suffix tree

### DIFF
--- a/UkkonenVisualization.elm
+++ b/UkkonenVisualization.elm
@@ -162,7 +162,7 @@ update action model =
 
                     steps = Array.fromList (initialState :: UkkonenAlgorithm.steps terminatedString)
                 in
-                    { model | string = terminatedString, steps = steps, currentStep = 0, inputField = noContent }
+                    { model | string = terminatedString, steps = steps, currentStep = 0 }
 
         Back ->
             { model | currentStep = max (model.currentStep - 1) 0 }


### PR DESCRIPTION
This keeps the current input string in the input field when the "build suffix
tree" button is clicked. This makes it easier to tweak the input string and see
how the change affects the suffix tree.